### PR TITLE
토큰 관련 기능 리팩토링

### DIFF
--- a/src/main/java/com/ffuntree/ffunfun/controller/FFunController.java
+++ b/src/main/java/com/ffuntree/ffunfun/controller/FFunController.java
@@ -1,5 +1,6 @@
 package com.ffuntree.ffunfun.controller;
 
+import com.ffuntree.ffunfun.data.common.AuthenticatedUser;
 import com.ffuntree.ffunfun.data.ffun.ExistUserDto;
 import com.ffuntree.ffunfun.data.ffun.FFunRoomInfoMemberDto;
 import com.ffuntree.ffunfun.data.ffun.FFunRoomRegisterDto;
@@ -7,6 +8,7 @@ import com.ffuntree.ffunfun.service.FFunService;
 import com.ffuntree.ffunfun.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("api/v1/ffun")
@@ -14,47 +16,45 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class FFunController {
 
-    private final UserService userService;
     private final FFunService ffunService;
 
     @PostMapping
     public void registerFFun(
-            @RequestHeader("Authorization") String accessToken,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
             @RequestBody FFunRoomRegisterDto ffunRoomRegisterDto) {
-        String ffunManagerEmail = userService.getUsernameFromToken(accessToken);
+        String ffunManagerEmail = authenticatedUser.getEmail();
         ffunService.makeFFunRoom(ffunRoomRegisterDto, ffunManagerEmail);
     }
 
     @PostMapping("/join/{ffunRoomId}")
     public void joinFFun(
-            @RequestHeader("Authorization") String accessToken,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
             @RequestParam String password,
             @PathVariable Long ffunRoomId) {
-        String userEmail = userService.getUsernameFromToken(accessToken);
+        String userEmail = authenticatedUser.getEmail();
         ffunService.joinFFun(userEmail, ffunRoomId, password);
     }
 
     @GetMapping("/exist/{ffunRoomId}")
     public ResponseEntity<ExistUserDto> existUser(
             @PathVariable Long ffunRoomId,
-            @RequestHeader("Authorization") String accessToken) {
-        String userEmail = userService.getUsernameFromToken(accessToken);
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+        String userEmail = authenticatedUser.getEmail();
         ExistUserDto existUser = ffunService.isExistUser(ffunRoomId, userEmail);
 
         return ResponseEntity.ok(existUser);
     }
 
     @GetMapping("/{ffunRoomId}")
-    public ResponseEntity<FFunRoomInfoMemberDto> getFFunRoomInfo(
-            @PathVariable Long ffunRoomId) {
+    public ResponseEntity<FFunRoomInfoMemberDto> getFFunRoomInfo(@PathVariable Long ffunRoomId) {
         FFunRoomInfoMemberDto ffunRoomInfo = ffunService.getFFunRoomInfo(ffunRoomId);
 
         return ResponseEntity.ok(ffunRoomInfo);
     }
 
     @DeleteMapping("/leave")
-    public void leaveFFun(@RequestHeader("Authorization") String accessToken) {
-        String userEmail = userService.getUsernameFromToken(accessToken);
+    public void leaveFFun(@AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+        String userEmail = authenticatedUser.getEmail();
         ffunService.leaveFFun(userEmail);
     }
 

--- a/src/main/java/com/ffuntree/ffunfun/controller/UserController.java
+++ b/src/main/java/com/ffuntree/ffunfun/controller/UserController.java
@@ -1,9 +1,11 @@
 package com.ffuntree.ffunfun.controller;
 
+import com.ffuntree.ffunfun.data.common.AuthenticatedUser;
 import com.ffuntree.ffunfun.data.user.UserInfoDto;
 import com.ffuntree.ffunfun.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("api/v1/user")
@@ -14,13 +16,13 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/info")
-    public ResponseEntity<UserInfoDto> getUserInfo(@RequestHeader("Authorization") String accessToken) {
-        return ResponseEntity.ok(userService.getUser(accessToken));
+    public ResponseEntity<UserInfoDto> getUserInfo(@AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+        return ResponseEntity.ok(userService.getUserInfo(authenticatedUser.getEmail()));
     }
 
     @DeleteMapping("/withdrawal")
-    public ResponseEntity<String> withdrawal(@RequestHeader("Authorization") String accessToken) {
-        userService.withdrawal(accessToken);
+    public ResponseEntity<String> withdrawal(@AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+        userService.withdrawal(authenticatedUser.getEmail());
         return ResponseEntity.ok("withdrawal success");
     }
 

--- a/src/main/java/com/ffuntree/ffunfun/data/common/AuthenticatedUser.java
+++ b/src/main/java/com/ffuntree/ffunfun/data/common/AuthenticatedUser.java
@@ -1,0 +1,18 @@
+package com.ffuntree.ffunfun.data.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class AuthenticatedUser {
+
+    private String email;
+    private Collection<? extends GrantedAuthority> authorities;
+
+}

--- a/src/main/java/com/ffuntree/ffunfun/data/user/UserInfoDto.java
+++ b/src/main/java/com/ffuntree/ffunfun/data/user/UserInfoDto.java
@@ -4,6 +4,7 @@ import com.ffuntree.ffunfun.data.ffun.FFunRoomSimpleInfoDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import org.springframework.lang.Nullable;
 
 @Data
 @AllArgsConstructor
@@ -17,13 +18,18 @@ public class UserInfoDto {
     private FFunRoomSimpleInfoDto ffunRoomInfo;
 
     public static UserInfoDto of(User user, String encodedProfileImageForBase64) {
-        return UserInfoDto.builder()
+        UserInfoDto build = UserInfoDto.builder()
                 .id(user.getId())
                 .email(user.getEmail())
                 .profileImage(encodedProfileImageForBase64)
                 .studentEmail(user.getStudentEmail())
-                .ffunRoomInfo(FFunRoomSimpleInfoDto.of(user.getFfunRoom()))
                 .build();
+
+        if (user.getFfunRoom() == null) {
+            build.setFfunRoomInfo(null);
+        }
+
+        return build;
     }
 
 }

--- a/src/main/java/com/ffuntree/ffunfun/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ffuntree/ffunfun/security/JwtAuthenticationFilter.java
@@ -5,18 +5,14 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.GenericFilterBean;
-import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
@@ -24,17 +20,16 @@ import java.io.IOException;
 @Slf4j
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
-@Component
-public class JwtAuthenticationFilter extends OncePerRequestFilter {
+public class JwtAuthenticationFilter extends GenericFilterBean {
 
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        log.info("[JwtAuthenticationFilter] doFilter 작동");
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        log.info("JwtAuthenticationFilter.doFilter");
 
         // 1. Request Header 에서 JWT 토큰 추출
-        String token = resolveToken((HttpServletRequest) request);
+        String token = resolveToken((HttpServletRequest) servletRequest);
 
         // 2. validateToken 으로 토큰 유효성 검사
         if (token != null && jwtTokenProvider.validateToken(token)) {
@@ -43,7 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
-        filterChain.doFilter(request, response);
+        filterChain.doFilter(servletRequest, servletResponse);
     }
 
     // Request Header 에서 토큰 정보 추출

--- a/src/main/java/com/ffuntree/ffunfun/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ffuntree/ffunfun/security/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +16,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
@@ -23,12 +25,13 @@ import java.io.IOException;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
 @Component
-public class JwtAuthenticationFilter extends GenericFilterBean {
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("[JwtAuthenticationFilter] doFilter 작동");
 
         // 1. Request Header 에서 JWT 토큰 추출
         String token = resolveToken((HttpServletRequest) request);
@@ -40,7 +43,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
-        chain.doFilter(request, response);
+        filterChain.doFilter(request, response);
     }
 
     // Request Header 에서 토큰 정보 추출

--- a/src/main/java/com/ffuntree/ffunfun/security/SecurityConfig.java
+++ b/src/main/java/com/ffuntree/ffunfun/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.ffuntree.ffunfun.security;
 
+import com.ffuntree.ffunfun.repository.UserRepository;
+import com.ffuntree.ffunfun.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -18,7 +20,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
@@ -41,10 +44,11 @@ public class SecurityConfig {
                         .requestMatchers("api/v1/user/sign-up").permitAll()
                         .requestMatchers("api/v1/user/social/**").permitAll()
                         .requestMatchers("api/v1/user/social/google").permitAll()
+                        .requestMatchers("test/test").permitAll()
                         .anyRequest().authenticated())
 
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .userDetailsService(new CustomUserDetailsService(passwordEncoder(), userRepository))
                 .build();
     }
 

--- a/src/main/java/com/ffuntree/ffunfun/security/SecurityConfig.java
+++ b/src/main/java/com/ffuntree/ffunfun/security/SecurityConfig.java
@@ -37,10 +37,10 @@ public class SecurityConfig {
 
                 .authorizeRequests(authorizeRequests -> authorizeRequests
                         // 로그인, 회원가입 요청은 누구나 가능
-                        .requestMatchers("api/v1/sign/sign-in").permitAll()
-                        .requestMatchers("api/v1/sign/sign-up").permitAll()
-                        .requestMatchers("api/v1/sign/social/**").permitAll()
-                        .requestMatchers("api/v1/sign/social/google").permitAll()
+                        .requestMatchers("api/v1/user/sign-in").permitAll()
+                        .requestMatchers("api/v1/user/sign-up").permitAll()
+                        .requestMatchers("api/v1/user/social/**").permitAll()
+                        .requestMatchers("api/v1/user/social/google").permitAll()
                         .anyRequest().permitAll())
 
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/ffuntree/ffunfun/security/SecurityConfig.java
+++ b/src/main/java/com/ffuntree/ffunfun/security/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                         .requestMatchers("api/v1/user/sign-up").permitAll()
                         .requestMatchers("api/v1/user/social/**").permitAll()
                         .requestMatchers("api/v1/user/social/google").permitAll()
-                        .anyRequest().permitAll())
+                        .anyRequest().authenticated())
 
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 

--- a/src/main/java/com/ffuntree/ffunfun/service/CustomUserDetailsService.java
+++ b/src/main/java/com/ffuntree/ffunfun/service/CustomUserDetailsService.java
@@ -13,8 +13,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {

--- a/src/main/java/com/ffuntree/ffunfun/service/UserService.java
+++ b/src/main/java/com/ffuntree/ffunfun/service/UserService.java
@@ -14,12 +14,11 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final CustomUserDetailsService customUserDetailsService;
     private final JwtTokenProvider jwtTokenProvider;
     private final FileUploadService fileUploadService;
 
-    public UserInfoDto getUser(String accessToken) {
-        User user = userRepository.findByEmail(getUsernameFromToken(accessToken)).orElseThrow(UserNotFoundException::new);
+    public UserInfoDto getUserInfo(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
         String encodedProfileImage = null;
         if (user.getProfileImage() != null) {
             encodedProfileImage = fileUploadService.loadFileAsBase64(user.getProfileImage().getFilename());
@@ -31,8 +30,8 @@ public class UserService {
         return jwtTokenProvider.getAuthentication(token).getName();
     }
 
-    public void withdrawal(String accessToken) {
-        User user = userRepository.findByEmail(getUsernameFromToken(accessToken)).orElseThrow(UserNotFoundException::new);
+    public void withdrawal(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
         userRepository.delete(user);
     }
 


### PR DESCRIPTION
## 리팩토링 사항
- 기존에는 @RequestHeader String accessToken 등으로 받아 UserService에게 건네둔 뒤, 유저 (혹은 username)을 받았습니다.
- 스프링 시큐리티를 적용하여 RequestHeader에서 토큰이 있는지 검사하고, 유저를 추출하는 과정을 간소화시킬 수 있었습니다.
- @AuthenticationPrincipal AuthenticatedUser user 등과 같이 받아 사용하면 됩니다.
- 유저 Entity가 Controller에 노출되는 것은 그닥 좋은 현상이 아니라고 생각하여 유저의 권한과 이메일을 갖고 있는 AuthenticatedUesr 클래스를 정의하여 사용하였습니다.